### PR TITLE
feat(Export All): Add a new option to ignore user provided tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ My preferred method is to use [AWS Vault](https://github.com/99designs/aws-vault
 
 ```
 # -p path to export (optional default is ./export)
-> node lib/run_export_all [-p ./export]
+# -i table to ignore when exporting (eg. audit_log, defaults to exporting all)
+> node lib/run_export_all [-p ./export] [-i table -i to_ignore]
 ```
 
 # Importing

--- a/src/run_export_all.ts
+++ b/src/run_export_all.ts
@@ -15,12 +15,21 @@ const argv = yargs
       required: false,
       default: './export',
     },
+    ignore: {
+      type: 'array',
+      alias: 'i',
+      description: 'table names to skip export of',
+      requiresArg: true,
+      required: false,
+      default: '[]',
+    },
   })
   .implies('with', 'replace').argv;
 
 const exportDynamoDB = new ExportDynamoDB({
   AWS,
   path: argv.path,
+  ignore: argv.ignore,
 });
 
 exportDynamoDB.process().finally(() => console.log('done'));


### PR DESCRIPTION
This is so we can give options like `lib/run_export_all -i some_audit_log -i another_large_table`.

I couldn't get yargs to handle the case of `lib/run_export_all -i one arg table list`. But this seems like a tweak to add later.